### PR TITLE
Add placeholder for OpenAI API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,15 @@ Rastgele eşleşme ile tek seferlik, P2P (WebRTC) metin sohbeti. **Tamamen istem
 4. `index.html`, `styles.css`, `app.js` dosyalarını GitHub Pages/Netlify ile yayınla.
 
 ### Yapay Zeka Kullanımı
-Tarayıcıda yapay zekanın çalışabilmesi için bir OpenAI API anahtarına ihtiyaç vardır. Geçici olarak anahtarı konsoldan tanımlayabilirsin:
+Tarayıcıda yapay zekanın çalışabilmesi için bir OpenAI API anahtarına ihtiyaç vardır. `index.html` dosyasındaki
 
 ```html
 <script>
-  window.OPENAI_API_KEY = "YOUR_KEY_HERE";
+  window.OPENAI_API_KEY = "BURAYA_OPENAI_API_ANAHTARINI_GİR";
 </script>
 ```
+
+satırını kendi anahtarınla güncelleyebilir veya geçici olarak konsoldan tanımlayabilirsin.
 
 Anahtar tanımlanmazsa yapay zeka modu çalışmaz.
 

--- a/index.html
+++ b/index.html
@@ -71,6 +71,9 @@
   <script src="https://unpkg.com/peerjs@1.5.2/dist/peerjs.min.js"></script>
 
   <!-- App -->
+  <script>
+    window.OPENAI_API_KEY = "BURAYA_OPENAI_API_ANAHTARINI_GİR";
+  </script>
   <script src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Define `window.OPENAI_API_KEY` in `index.html` for built-in AI chat fallback
- Document how to replace the placeholder API key in `README`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e78d1524832987eeebbd104c7140