### PR TITLE
Improve AI fallback compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .env
 env.js
 client_secret.json
+node_modules

--- a/README.md
+++ b/README.md
@@ -15,12 +15,13 @@ Rastgele eşleşme ile tek seferlik, P2P (WebRTC) metin sohbeti. **Tamamen istem
    cp .env.example .env
    # .env içinde GOOGLE_API_KEY ve GOOGLE_CLIENT_ID/SECRET değerlerini düzenle
    ```
-5. Tarayıcıya gerekli OAuth bilgilerini aktarmak için `node inject-env.js` komutunu çalıştır (bu, `env.js` dosyasını üretir).
-6. Sunucuyu başlat: `node server.js` (statik dosyaları ve `/api/ai` uç noktasını sağlar).
-7. `index.html`, `styles.css`, `app.js` dosyalarını ve üretilen `env.js`'i (git'e ekleme) yayınla.
+5. Gerekli paketleri yükle: `npm install`.
+6. Tarayıcıya gerekli OAuth bilgilerini aktarmak için `node inject-env.js` komutunu çalıştır (bu, `env.js` dosyasını üretir).
+7. Sunucuyu başlat: `node server.js` (statik dosyaları ve `/api/ai` uç noktasını sağlar).
+8. `index.html`, `styles.css`, `app.js` dosyalarını ve üretilen `env.js`'i (git'e ekleme) yayınla.
 
 ### Yapay Zeka Kullanımı
-Tarayıcı Google API anahtarına doğrudan erişmez. `server.js`, `.env` dosyasındaki `GOOGLE_API_KEY` değerini kullanarak Gemini API'ye istek yapar. Anahtar tanımlanmazsa yapay zeka modu çalışmaz.
+Tarayıcı Google API anahtarına doğrudan erişmez. `server.js`, `.env` dosyasındaki `GOOGLE_API_KEY` değerini kullanarak Gemini API'ye istek yapar. Anahtar tanımlanmazsa yapay zeka modu devre dışı kalır ancak sunucu çalışmaya devam eder.
 
 ### Google OAuth
 Google ile kimlik doğrulaması için `.env` dosyasındaki `GOOGLE_CLIENT_ID` ve `GOOGLE_CLIENT_SECRET` değerlerini doldur. Gerekirse `client_secret.json.example` dosyasını `client_secret.json` olarak kopyalayarak sunucu tarafında kullanabilirsin.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "my-site",
+  "version": "1.0.0",
+  "main": "server.js",
+  "scripts": {
+    "test": "node -c server.js"
+  },
+  "dependencies": {
+    "node-fetch": "^3.3.2"
+  }
+}
+

--- a/server.js
+++ b/server.js
@@ -2,13 +2,12 @@ const http = require('http');
 const fs = require('fs');
 const path = require('path');
 
+// Ensure `fetch` is available in older Node versions
+const fetch = global.fetch || ((...args) =>
+  import('node-fetch').then(({ default: f }) => f(...args)));
+
 const PORT = process.env.PORT || 3000;
 const GOOGLE_API_KEY = process.env.GOOGLE_API_KEY;
-
-if (!GOOGLE_API_KEY) {
-  console.error('Missing GOOGLE_API_KEY environment variable.');
-  process.exit(1);
-}
 
 function sendJson(res, status, obj) {
   res.writeHead(status, { 'Content-Type': 'application/json' });
@@ -17,6 +16,9 @@ function sendJson(res, status, obj) {
 
 const server = http.createServer((req, res) => {
   if (req.method === 'POST' && req.url === '/api/ai') {
+    if (!GOOGLE_API_KEY) {
+      return sendJson(res, 500, { error: 'GOOGLE_API_KEY is not set' });
+    }
     let body = '';
     req.on('data', chunk => {
       body += chunk;


### PR DESCRIPTION
## Summary
- ensure server's AI endpoint works on Node versions without global `fetch`
- handle missing `GOOGLE_API_KEY` without exiting the server
- document dependency installation and optional AI key in setup instructions

## Testing
- `npm test`
- `npm install` *(fails: 403 Forbidden retrieving node-fetch)*

------
https://chatgpt.com/codex/tasks/task_e_68b3001ce1608329b4fdb1b9f3cfccf5