### PR TITLE
Remove Google sign-in and switch AI reference to OpenAI

### DIFF
--- a/app.js
+++ b/app.js
@@ -76,27 +76,6 @@ function sanitize(text) {
   return text.replace(/[\u0000-\u001F\u007F-\u009F]/g, "");
 }
 
-// Google OAuth (optional)
-window.initGoogleAuth = function () {
-  if (!window.google || !window.GOOGLE_CLIENT_ID) {
-    console.warn("Google OAuth client ID missing.");
-    return;
-  }
-  window.google.accounts.id.initialize({
-    client_id: window.GOOGLE_CLIENT_ID,
-    callback: (res) => {
-      console.log("Google credential:", res.credential);
-    },
-  });
-  const btn = document.getElementById("googleSignIn");
-  if (btn) {
-    window.google.accounts.id.renderButton(btn, {
-      theme: "outline",
-      size: "large",
-    });
-  }
-};
-
 // Tema
 (function initTheme(){
   const key = "otc-theme";
@@ -251,7 +230,7 @@ function connectToAI() {
   }
   setStatus("Yapay zekayla sohbet ediyorsunuz.");
   roomChip.textContent = "AI";
-  peerInfo.textContent = "Gemini";
+  peerInfo.textContent = "OpenAI";
   setConnectedUI(true);
   addMsg("Sistem: Yapay zeka bağlandı.", "sys");
 }

--- a/index.html
+++ b/index.html
@@ -23,8 +23,6 @@
         <input id="nickname" type="text" maxlength="20" placeholder="Örn: Deniz" />
       </div>
 
-      <div id="googleSignIn"></div>
-
       <div class="actions">
         <button id="startBtn" class="primary">Sohbete Başla</button>
         <button id="nextBtn" class="ghost" disabled>Sonraki</button>
@@ -39,7 +37,7 @@
             <li>Hiçbir mesaj sunucuda saklanmaz. Mesajlar eşler arası (P2P) aktarılır.</li>
             <li>Eşleştirme için ücretsiz <b>Firebase Realtime Database</b>, bağlantı için <b>PeerJS (WebRTC)</b> kullanılır.</li>
             <li>İlk kurulum için <code>app.js</code> içindeki <code>firebaseConfig</code>'i doldurmalısın.</li>
-            <li>5 saniye içinde eşleşme bulunamazsa Google Gemini ile basit bir yapay zekayla sohbet başlar.</li>
+            <li>5 saniye içinde eşleşme bulunamazsa OpenAI ile basit bir yapay zekayla sohbet başlar.</li>
           </ul>
         </details>
       </section>
@@ -71,9 +69,6 @@
   <script src="https://www.gstatic.com/firebasejs/10.13.2/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/10.13.2/firebase-database-compat.js"></script>
   <script src="https://unpkg.com/peerjs@1.5.2/dist/peerjs.min.js"></script>
-
-  <!-- Google Identity Services -->
-  <script src="https://accounts.google.com/gsi/client" async defer onload="initGoogleAuth()"></script>
 
   <!-- Environment variables (generated) -->
   <script src="env.js"></script>


### PR DESCRIPTION
## Summary
- remove Google sign-in button and identity script
- drop Google OAuth initialization and update AI label to OpenAI
- replace user-facing text mentioning Google Gemini with OpenAI

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b305619f188329a5633e1be77eea0b