### PR TITLE
Remove env.js injection and Google client credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 .env
-env.js
 client_secret.json
 node_modules

--- a/README.md
+++ b/README.md
@@ -10,15 +10,14 @@ Rastgele eşleşme ile tek seferlik, P2P (WebRTC) metin sohbeti. **Tamamen istem
 1. Firebase projesi oluştur: https://console.firebase.google.com  
 2. Realtime Database -> **Start in test mode** (deneme içindir).  
 3. `app.js` içindeki `firebaseConfig` alanını kendi proje ayarlarınla doldur.
-4. `.env.example` dosyasını `.env` olarak kopyala ve Google API anahtarı ile OAuth bilgilerini doldur:
+4. `.env.example` dosyasını `.env` olarak kopyala ve Google API anahtarını doldur:
    ```
    cp .env.example .env
-   # .env içinde GOOGLE_API_KEY ve GOOGLE_CLIENT_ID/SECRET değerlerini düzenle
+    # .env içinde GOOGLE_API_KEY değerini düzenle
    ```
 5. Gerekli paketleri yükle: `npm install`.
-6. Tarayıcıya gerekli OAuth bilgilerini aktarmak için `node inject-env.js` komutunu çalıştır (bu, `env.js` dosyasını üretir).
-7. Sunucuyu başlat: `node server.js` (statik dosyaları ve `/api/ai` uç noktasını sağlar).
-8. `index.html`, `styles.css`, `app.js` dosyalarını ve üretilen `env.js`'i (git'e ekleme) yayınla.
+6. Sunucuyu başlat: `node server.js` (statik dosyaları ve `/api/ai` uç noktasını sağlar).
+7. `index.html`, `styles.css` ve `app.js` dosyalarını yayınla.
 
 ### Yapay Zeka Kullanımı
 Tarayıcı Google API anahtarına doğrudan erişmez. `server.js`, `.env` dosyasındaki `GOOGLE_API_KEY` değerini kullanarak Gemini API'ye istek yapar. Anahtar tanımlanmazsa yapay zeka modu devre dışı kalır ancak sunucu çalışmaya devam eder.
@@ -36,7 +35,7 @@ curl -X POST "https://generativelanguage.googleapis.com/v1beta/models/gemini-pro
 ```
 
 ### Google OAuth
-Google ile kimlik doğrulaması için `.env` dosyasındaki `GOOGLE_CLIENT_ID` ve `GOOGLE_CLIENT_SECRET` değerlerini doldur. Gerekirse `client_secret.json.example` dosyasını `client_secret.json` olarak kopyalayarak sunucu tarafında kullanabilirsin.
+Google ile kimlik doğrulaması yapmak için `index.html` dosyasında `window.GOOGLE_CLIENT_ID` tanımlayabilir ve gerekirse `client_secret.json.example` dosyasını `client_secret.json` olarak kopyalayarak sunucu tarafında kullanabilirsin.
 
 > Not: Test modunda veritabanı herkese açık olabilir. Üretimde güvenlik kurallarını kısıtla.
 

--- a/index.html
+++ b/index.html
@@ -75,9 +75,6 @@
   <!-- Google Identity Services -->
   <script src="https://accounts.google.com/gsi/client" async defer onload="initGoogleAuth()"></script>
 
-  <!-- Environment variables (generated) -->
-  <script src="env.js"></script>
-
   <!-- App -->
   <script src="app.js"></script>
 </body>

--- a/inject-env.js
+++ b/inject-env.js
@@ -15,13 +15,5 @@ if (fs.existsSync(envPath)) {
   }
 }
 
-const envVars = {
-  GOOGLE_CLIENT_ID: process.env.GOOGLE_CLIENT_ID || '',
-  GOOGLE_CLIENT_SECRET: process.env.GOOGLE_CLIENT_SECRET || ''
-};
-
-const content = `window.GOOGLE_CLIENT_ID = ${JSON.stringify(envVars.GOOGLE_CLIENT_ID)};
-window.GOOGLE_CLIENT_SECRET = ${JSON.stringify(envVars.GOOGLE_CLIENT_SECRET)};`;
-
-fs.writeFileSync(path.join(__dirname, 'env.js'), content);
-console.log('env.js generated');
+// Artık tarayıcıya değişken aktarmaya gerek yok.
+module.exports = process.env;


### PR DESCRIPTION
## Summary
- Stop generating env.js and exporting Google OAuth credentials
- Drop env.js script usage and update documentation
- Clean up .gitignore accordingly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b30561e938832995bad89e53c9c9ff