### PR TITLE
Use dotenv for environment variable injection

### DIFF
--- a/inject-env.js
+++ b/inject-env.js
@@ -1,27 +1,16 @@
 const fs = require('fs');
 const path = require('path');
 
-// Basit .env yükleyici
-const envPath = path.join(__dirname, '.env');
-if (fs.existsSync(envPath)) {
-  const lines = fs.readFileSync(envPath, 'utf-8').split('\n');
-  for (const line of lines) {
-    const match = line.match(/^([^=]+)=?(.*)$/);
-    if (match) {
-      const key = match[1].trim();
-      const value = match[2].trim();
-      if (key) process.env[key] = value;
-    }
-  }
-}
+require('dotenv').config();
 
 const envVars = {
   GOOGLE_CLIENT_ID: process.env.GOOGLE_CLIENT_ID || '',
   GOOGLE_CLIENT_SECRET: process.env.GOOGLE_CLIENT_SECRET || ''
 };
 
-const content = `window.GOOGLE_CLIENT_ID = ${JSON.stringify(envVars.GOOGLE_CLIENT_ID)};
-window.GOOGLE_CLIENT_SECRET = ${JSON.stringify(envVars.GOOGLE_CLIENT_SECRET)};`;
+const content = Object.entries(envVars)
+  .map(([key, value]) => `window.${key} = ${JSON.stringify(value)};`)
+  .join('\n');
 
 fs.writeFileSync(path.join(__dirname, 'env.js'), content);
 console.log('env.js generated');

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "test": "node -c server.js"
   },
   "dependencies": {
-    "node-fetch": "^3.3.2"
+    "node-fetch": "^3.3.2",
+    "dotenv": "^16.4.5"
   }
 }
 


### PR DESCRIPTION
## Summary
- replace manual .env parsing with `dotenv` and build env.js from `process.env`
- add `dotenv` dependency to project

## Testing
- `npm test`
- `node -c inject-env.js`
- `node inject-env.js` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68b44e390dc08329a59c5a7b79ba64cf