### PR TITLE
Add onDisconnect cleanup for queue

### DIFF
--- a/app.js
+++ b/app.js
@@ -134,6 +134,7 @@ function initFirebase() {
   const app = firebase.initializeApp(firebaseConfig);
   appState.db = firebase.database();
   appState.queueRef = appState.db.ref("queue"); // tek-slotluk basit kuyruk
+  appState.db.ref("queue").onDisconnect().remove();
 }
 
 function initPeer() {


### PR DESCRIPTION
## Summary
- remove any lingering queue entry on Firebase disconnect to avoid stale matches

## Testing
- `npm test`
- `npm install firebase --no-save` *(fails: 403 Forbidden)*
- `node -e "const firebase = require('firebase');"` *(fails: Cannot find module)*

------
https://chatgpt.com/codex/tasks/task_e_68b44e38ec008329b61525530a0f517b