### PR TITLE
Add user feedback controls and profile page

### DIFF
--- a/app.js
+++ b/app.js
@@ -55,6 +55,11 @@ const messagesEl = $("#messages");
 const roomChip = $("#roomChip");
 const peerInfo = $("#peerInfo");
 const themeToggle = $("#themeToggle");
+const likeBtn = $("#likeBtn");
+const dislikeBtn = $("#dislikeBtn");
+const changeBtn = $("#changeBtn");
+const skipBtn = $("#skipBtn");
+const profileBtn = $("#profileBtn");
 let nextBtnTimer = null;
 
 function setStatus(t) {
@@ -71,6 +76,10 @@ function setConnectedUI(connected) {
   sendBtn.disabled = !connected;
   endBtn.disabled = !connected && !appState.waiting;
   nextBtn.disabled = !connected && !appState.waiting;
+  likeBtn.disabled = !connected;
+  dislikeBtn.disabled = !connected;
+  changeBtn.disabled = !connected;
+  skipBtn.disabled = !connected;
   chatCard.classList.toggle("hidden", !connected && !appState.waiting);
 }
 function sanitize(text) {
@@ -138,6 +147,26 @@ sendForm.addEventListener("submit", (e) => {
   } else if (appState.ai) {
     aiSend(text);
   }
+});
+
+likeBtn.addEventListener("click", () => {
+  addMsg("Sistem: Kullanıcıyı beğendiniz.", "sys");
+});
+
+dislikeBtn.addEventListener("click", () => {
+  addMsg("Sistem: Kullanıcıyı beğenmediniz.", "sys");
+});
+
+changeBtn.addEventListener("click", () => {
+  addMsg("Sistem: Değiştir butonuna basıldı.", "sys");
+});
+
+skipBtn.addEventListener("click", () => {
+  addMsg("Sistem: Geç butonuna basıldı.", "sys");
+});
+
+profileBtn.addEventListener("click", () => {
+  window.location.href = "profile.html";
 });
 
 // ---- 5) Firebase & PeerJS Kurulum ----

--- a/index.html
+++ b/index.html
@@ -10,7 +10,10 @@
 <body>
   <header class="site-header">
     <div class="brand">One‑Time <span>Chat</span></div>
-    <button id="themeToggle" aria-label="Tema değiştir">🌓</button>
+    <div class="header-buttons">
+      <button id="profileBtn" class="ghost">Profil</button>
+      <button id="themeToggle" aria-label="Tema değiştir">🌓</button>
+    </div>
   </header>
 
   <main class="container">
@@ -56,6 +59,12 @@
         <input id="messageInput" type="text" placeholder="Mesaj yaz..." autocomplete="off" maxlength="500" />
         <button id="sendBtn" class="primary" type="submit" disabled>Gönder</button>
       </form>
+      <div class="extraActions">
+        <button id="likeBtn" class="ghost" disabled>Beğendim</button>
+        <button id="dislikeBtn" class="ghost" disabled>Beğenmedim</button>
+        <button id="changeBtn" class="ghost" disabled>Değiştir</button>
+        <button id="skipBtn" class="ghost" disabled>Geç</button>
+      </div>
     </section>
   </main>
 

--- a/profile.html
+++ b/profile.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+  <meta charset="UTF-8" />
+  <title>Profil</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <main class="container">
+    <section class="card">
+      <h1>Profil</h1>
+      <p>Profil bilgileri burada gösterilecek.</p>
+    </section>
+  </main>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -44,6 +44,8 @@ body {
 }
 .site-footer { border-top: 1px solid var(--border); border-bottom: none; justify-content: center; }
 
+.header-buttons { display: flex; gap: 8px; }
+
 .brand { font-weight: 800; letter-spacing: 0.2px; }
 .brand span { color: var(--accent); }
 
@@ -76,6 +78,8 @@ body {
 .row input:focus { border-color: var(--accent); }
 
 .actions { display: flex; gap: 10px; margin: 16px 0; flex-wrap: wrap; }
+
+.extraActions { display: flex; gap: 10px; margin-top: 10px; flex-wrap: wrap; }
 
 button {
   border: none;


### PR DESCRIPTION
## Summary
- Add profile button to header and simple profile page
- Enable user feedback buttons (like, dislike, change, skip) during chats
- Style new controls and integrate with chat UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b45dfa7c6083299087100f856b86b3