### PR TITLE
Add profile fields and unique nickname storage

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,8 +22,8 @@
       <p class="muted">HTML, CSS ve JavaScript ile çalışan; ücretsiz, uçtan uca eşleştirmeli, tek seferlik bir metin sohbeti.</p>
 
       <div class="row">
-        <label for="nickname">Takma ad (isteğe bağlı)</label>
-        <input id="nickname" type="text" maxlength="20" placeholder="Örn: Deniz" />
+        <label for="nickname">Takma ad</label>
+        <input id="nickname" type="text" maxlength="20" placeholder="Örn: Deniz" readonly />
       </div>
 
       <div class="actions">
@@ -81,6 +81,11 @@
 
   <!-- Environment variables (generated) -->
   <script src="env.js"></script>
+
+  <script src="profile.js"></script>
+  <script>
+    document.getElementById('nickname').value = getOrCreateNickname();
+  </script>
 
   <!-- App -->
   <script src="app.js"></script>

--- a/profile.html
+++ b/profile.html
@@ -9,8 +9,78 @@
   <main class="container">
     <section class="card">
       <h1>Profil</h1>
-      <p>Profil bilgileri burada gösterilecek.</p>
+      <form id="profileForm">
+        <div class="row">
+          <label for="firstName">Ad</label>
+          <input id="firstName" type="text" required />
+        </div>
+        <div class="row">
+          <label for="lastName">Soyad</label>
+          <input id="lastName" type="text" required />
+        </div>
+        <div class="row">
+          <label for="birthDate">Doğum Tarihi</label>
+          <input id="birthDate" type="date" required />
+        </div>
+        <div class="row">
+          <label for="gender">Cinsiyet</label>
+          <select id="gender" required>
+            <option value="">Seçiniz</option>
+            <option value="female">Kadın</option>
+            <option value="male">Erkek</option>
+            <option value="other">Diğer</option>
+          </select>
+        </div>
+        <div class="row">
+          <label for="city">Şehir</label>
+          <input id="city" type="text" required />
+        </div>
+        <div class="row">
+          <label for="email">E-posta (opsiyonel)</label>
+          <input id="email" type="email" />
+        </div>
+        <div class="row">
+          <label for="phone">Telefon (opsiyonel)</label>
+          <input id="phone" type="tel" />
+        </div>
+        <div class="row">
+          <label for="nickname">Takma Ad</label>
+          <input id="nickname" type="text" readonly />
+        </div>
+        <div class="actions">
+          <button class="primary" type="submit">Kaydet</button>
+        </div>
+      </form>
     </section>
   </main>
 </body>
+<script src="profile.js"></script>
+<script>
+  const form = document.getElementById('profileForm');
+  const data = getProfile();
+  document.getElementById('firstName').value = data.firstName || '';
+  document.getElementById('lastName').value = data.lastName || '';
+  document.getElementById('birthDate').value = data.birthDate || '';
+  document.getElementById('gender').value = data.gender || '';
+  document.getElementById('city').value = data.city || '';
+  document.getElementById('email').value = data.email || '';
+  document.getElementById('phone').value = data.phone || '';
+  document.getElementById('nickname').value = getOrCreateNickname();
+
+  form.addEventListener('submit', (e) => {
+    e.preventDefault();
+    const updated = {
+      firstName: document.getElementById('firstName').value.trim(),
+      lastName: document.getElementById('lastName').value.trim(),
+      birthDate: document.getElementById('birthDate').value,
+      gender: document.getElementById('gender').value,
+      city: document.getElementById('city').value.trim(),
+      email: document.getElementById('email').value.trim(),
+      phone: document.getElementById('phone').value.trim(),
+      nickname: document.getElementById('nickname').value.trim(),
+    };
+    saveProfile(updated);
+    alert('Profil kaydedildi');
+  });
+</script>
 </html>

--- a/profile.js
+++ b/profile.js
@@ -1,0 +1,24 @@
+function getProfile() {
+  try {
+    return JSON.parse(localStorage.getItem('profile') || '{}');
+  } catch (e) {
+    return {};
+  }
+}
+
+function saveProfile(data) {
+  localStorage.setItem('profile', JSON.stringify(data));
+}
+
+function getOrCreateNickname() {
+  const data = getProfile();
+  if (!data.nickname) {
+    data.nickname = 'user-' + Math.random().toString(36).substring(2, 8);
+    saveProfile(data);
+  }
+  return data.nickname;
+}
+
+window.getProfile = getProfile;
+window.saveProfile = saveProfile;
+window.getOrCreateNickname = getOrCreateNickname;


### PR DESCRIPTION
## Summary
- Add profile page with form fields for name, birth date, gender, city, optional email and phone
- Generate/store unique nicknames and load them into chat automatically
- Display nickname as read-only in chat setup to keep other details hidden

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b45f17acac832991287027fce858bd