### PR TITLE
Add gender-based avatar to profile

### DIFF
--- a/img/avatar-female.svg
+++ b/img/avatar-female.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <circle cx="32" cy="20" r="12" fill="#ff6b6b"/>
+  <path d="M12 56c0-11 9-20 20-20s20 9 20 20" fill="#ff6b6b"/>
+</svg>

--- a/img/avatar-male.svg
+++ b/img/avatar-male.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <circle cx="32" cy="20" r="12" fill="#7cc4ff"/>
+  <path d="M12 56c0-11 9-20 20-20s20 9 20 20" fill="#7cc4ff"/>
+</svg>

--- a/img/avatar-neutral.svg
+++ b/img/avatar-neutral.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <circle cx="32" cy="20" r="12" fill="#9fb0c3"/>
+  <path d="M12 56c0-11 9-20 20-20s20 9 20 20" fill="#9fb0c3"/>
+</svg>

--- a/profile.html
+++ b/profile.html
@@ -9,6 +9,7 @@
   <main class="container">
     <section class="card">
       <h1>Profil</h1>
+      <img id="avatar" class="avatar" alt="Profil resmi" />
       <form id="profileForm">
         <div class="row">
           <label for="firstName">Ad</label>
@@ -66,6 +67,16 @@
   document.getElementById('email').value = data.email || '';
   document.getElementById('phone').value = data.phone || '';
   document.getElementById('nickname').value = getOrCreateNickname();
+
+  const avatar = document.getElementById('avatar');
+  function updateAvatar() {
+    const g = document.getElementById('gender').value;
+    if (g === 'female') avatar.src = 'img/avatar-female.svg';
+    else if (g === 'male') avatar.src = 'img/avatar-male.svg';
+    else avatar.src = 'img/avatar-neutral.svg';
+  }
+  updateAvatar();
+  document.getElementById('gender').addEventListener('change', updateAvatar);
 
   form.addEventListener('submit', (e) => {
     e.preventDefault();

--- a/styles.css
+++ b/styles.css
@@ -66,6 +66,16 @@ body {
 .intro h1 { margin: 0 0 8px; }
 .muted { color: var(--muted); }
 
+.avatar {
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  border: 2px solid var(--border);
+  background: var(--chip);
+  display: block;
+  margin: 0 auto 16px;
+}
+
 .row { display: grid; gap: 6px; margin: 14px 0; }
 .row input {
   padding: 12px 14px;


### PR DESCRIPTION
## Summary
- Display gender-specific avatar on profile page
- Style avatar and include SVG icons for male, female and neutral
- Load avatar dynamically based on selected gender

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b460330b548329a61f193706e3917b