### PR TITLE
Add friend option and auto-restart chats

### DIFF
--- a/app.js
+++ b/app.js
@@ -59,6 +59,7 @@ const likeBtn = $("#likeBtn");
 const dislikeBtn = $("#dislikeBtn");
 const changeBtn = $("#changeBtn");
 const skipBtn = $("#skipBtn");
+const addFriendBtn = $("#addFriendBtn");
 const profileBtn = $("#profileBtn");
 let nextBtnTimer = null;
 
@@ -80,6 +81,8 @@ function setConnectedUI(connected) {
   dislikeBtn.disabled = !connected;
   changeBtn.disabled = !connected;
   skipBtn.disabled = !connected;
+  addFriendBtn.disabled = true;
+  addFriendBtn.classList.add("hidden");
   chatCard.classList.toggle("hidden", !connected && !appState.waiting);
 }
 function sanitize(text) {
@@ -151,14 +154,26 @@ sendForm.addEventListener("submit", (e) => {
 
 likeBtn.addEventListener("click", () => {
   addMsg("Sistem: Kullanıcıyı beğendiniz.", "sys");
+  addFriendBtn.classList.remove("hidden");
+  addFriendBtn.disabled = false;
 });
 
 dislikeBtn.addEventListener("click", () => {
   addMsg("Sistem: Kullanıcıyı beğenmediniz.", "sys");
+  endCurrent(true);
+  attemptMatch();
 });
 
 changeBtn.addEventListener("click", () => {
   addMsg("Sistem: Değiştir butonuna basıldı.", "sys");
+  endCurrent(true);
+  attemptMatch();
+});
+
+addFriendBtn.addEventListener("click", () => {
+  addMsg("Sistem: Kullanıcı arkadaş olarak eklendi.", "sys");
+  addFriendBtn.classList.add("hidden");
+  addFriendBtn.disabled = true;
 });
 
 skipBtn.addEventListener("click", () => {

--- a/index.html
+++ b/index.html
@@ -64,6 +64,7 @@
         <button id="dislikeBtn" class="ghost" disabled>Beğenmedim</button>
         <button id="changeBtn" class="ghost" disabled>Değiştir</button>
         <button id="skipBtn" class="ghost" disabled>Geç</button>
+        <button id="addFriendBtn" class="ghost hidden" disabled>Arkadaş olarak ekle</button>
       </div>
     </section>
   </main>

--- a/styles.css
+++ b/styles.css
@@ -67,9 +67,9 @@ body {
 .muted { color: var(--muted); }
 
 .avatar {
-  width: 80px;
-  height: 80px;
-  border-radius: 50%;
+  width: 50px;
+  height: 50px;
+  border-radius: 8px;
   border: 2px solid var(--border);
   background: var(--chip);
   display: block;


### PR DESCRIPTION
## Summary
- Shrink profile avatar to a 50px square
- Add "Arkadaş olarak ekle" button after liking a user without showing personal info
- Start a new chat automatically when using "Beğenmedim" or "Değiştir"

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4640b898883299125df55d59b40d8