### PR TITLE
Add simple real-time chat app with AI fallback

### DIFF
--- a/chat/README.md
+++ b/chat/README.md
@@ -1,0 +1,28 @@
+# Hızlı Sohbet Uygulaması
+
+Bu klasör, kullanıcıları hızlı şekilde eşleştiren ve kısa süre içinde eşleşme bulunamazsa yapay zekâ ile sohbet başlatan basit bir örnek uygulama içerir.
+
+## Özellikler
+- Takma ad ile giriş
+- 1-1 hızlı sohbet için gerçek kullanıcı eşleştirmesi
+- 5 saniye içinde kullanıcı bulunamazsa otomatik yapay zekâ sohbeti
+- OpenAI API entegrasyonu
+- Socket.io ile gerçek zamanlı mesajlaşma
+
+## Kurulum
+1. Bağımlılıkları yükleyin (depo kökünde):
+   ```bash
+   npm install
+   ```
+2. Bir `.env` dosyası oluşturup OpenAI anahtarınızı ekleyin:
+   ```env
+   OPENAI_API_KEY=YOUR_KEY_HERE
+   ```
+3. Sunucuyu başlatın:
+   ```bash
+   npm start
+   ```
+4. Tarayıcınızda [http://localhost:3000](http://localhost:3000) adresini açın.
+
+## Not
+Bu örnek basit olması için hazırlanmıştır; gerçek üretim ortamları için ek güvenlik ve hata kontrolleri gereklidir.

--- a/chat/index.html
+++ b/chat/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+  <meta charset="UTF-8" />
+  <title>Hızlı Sohbet</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div id="login">
+    <h2>Sohbete Katıl</h2>
+    <input id="nickname" placeholder="Takma ad" />
+    <button id="joinBtn">Katıl</button>
+  </div>
+  <div id="chat" class="hidden">
+    <div id="messages"></div>
+    <input id="msgInput" autocomplete="off" placeholder="Mesaj yaz..." />
+    <button id="sendBtn">Gönder</button>
+  </div>
+  <script src="/socket.io/socket.io.js"></script>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/chat/script.js
+++ b/chat/script.js
@@ -1,0 +1,49 @@
+const socket = io();
+
+const login = document.getElementById('login');
+const chat = document.getElementById('chat');
+const nicknameInput = document.getElementById('nickname');
+const joinBtn = document.getElementById('joinBtn');
+const messages = document.getElementById('messages');
+const msgInput = document.getElementById('msgInput');
+const sendBtn = document.getElementById('sendBtn');
+
+joinBtn.addEventListener('click', () => {
+  const nick = nicknameInput.value.trim();
+  if (!nick) return;
+  socket.emit('join', nick);
+  login.classList.add('hidden');
+  chat.classList.remove('hidden');
+});
+
+function send() {
+  const text = msgInput.value.trim();
+  if (text === '') return;
+  socket.emit('message', text);
+  addMessage('Ben', text);
+  msgInput.value = '';
+}
+
+sendBtn.addEventListener('click', send);
+msgInput.addEventListener('keypress', e => {
+  if (e.key === 'Enter') send();
+});
+
+function addMessage(nick, text) {
+  const div = document.createElement('div');
+  div.innerHTML = `<strong>${nick}:</strong> ${text}`;
+  messages.appendChild(div);
+  messages.scrollTop = messages.scrollHeight;
+}
+
+socket.on('message', data => {
+  addMessage(data.nickname, data.text);
+});
+
+socket.on('system', msg => {
+  const div = document.createElement('div');
+  div.className = 'system';
+  div.textContent = msg;
+  messages.appendChild(div);
+  messages.scrollTop = messages.scrollHeight;
+});

--- a/chat/server.js
+++ b/chat/server.js
@@ -1,0 +1,77 @@
+require('dotenv').config();
+const express = require('express');
+const http = require('http');
+const { Server } = require('socket.io');
+const OpenAI = require('openai');
+const path = require('path');
+
+const app = express();
+const server = http.createServer(app);
+const io = new Server(server);
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+app.use(express.static(__dirname));
+
+const waiting = [];
+
+io.on('connection', socket => {
+  let timeout;
+
+  socket.on('join', nickname => {
+    socket.nickname = nickname || 'Anon';
+    if (waiting.length > 0) {
+      const peer = waiting.shift();
+      const room = `${socket.id}#${peer.id}`;
+      socket.join(room);
+      peer.join(room);
+      socket.room = room;
+      peer.room = room;
+      io.to(room).emit('system', `${socket.nickname} ve ${peer.nickname} bağlandı.`);
+    } else {
+      waiting.push(socket);
+      timeout = setTimeout(() => {
+        const idx = waiting.indexOf(socket);
+        if (idx !== -1) waiting.splice(idx,1);
+        socket.isWithAI = true;
+        socket.room = socket.id;
+        socket.join(socket.room);
+        socket.emit('system', 'Yapay zekâ bağlandı.');
+      }, 5000);
+    }
+  });
+
+  socket.on('message', async text => {
+    if (socket.isWithAI) {
+      try {
+        const completion = await openai.chat.completions.create({
+          model: 'gpt-3.5-turbo',
+          messages: [
+            { role: 'system', content: 'Sen arkadaşça sohbet eden yardımcı bir yapay zekâsın.' },
+            { role: 'user', content: text }
+          ]
+        });
+        const reply = completion.choices[0].message.content.trim();
+        socket.emit('message', { nickname: 'AI', text: reply });
+      } catch (err) {
+        console.error('AI error', err);
+        socket.emit('message', { nickname: 'AI', text: 'Bir hata oluştu.' });
+      }
+    } else if (socket.room) {
+      socket.to(socket.room).emit('message', { nickname: socket.nickname, text });
+    }
+  });
+
+  socket.on('disconnect', () => {
+    if (timeout) clearTimeout(timeout);
+    const idx = waiting.indexOf(socket);
+    if (idx !== -1) waiting.splice(idx,1);
+    if (socket.room && !socket.isWithAI) {
+      socket.to(socket.room).emit('system', 'Sohbetten ayrıldı.');
+    }
+  });
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`Chat server running at http://localhost:${PORT}`);
+});

--- a/chat/style.css
+++ b/chat/style.css
@@ -1,0 +1,37 @@
+body {
+  font-family: Arial, sans-serif;
+  background: #f2f2f2;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  margin: 0;
+}
+
+.hidden { display: none; }
+
+#chat {
+  width: 320px;
+}
+
+#messages {
+  height: 300px;
+  overflow-y: auto;
+  border: 1px solid #ccc;
+  background: #fff;
+  padding: 5px;
+  margin-bottom: 5px;
+}
+
+#msgInput {
+  width: 70%;
+}
+
+#sendBtn {
+  width: 28%;
+}
+
+.system {
+  color: #777;
+  font-style: italic;
+}

--- a/package.json
+++ b/package.json
@@ -3,11 +3,14 @@
   "version": "1.0.0",
   "main": "server.js",
   "scripts": {
-    "test": "node -c server.js"
+    "test": "node -c server.js && node -c chat/server.js",
+    "start": "node chat/server.js"
   },
   "dependencies": {
+    "dotenv": "^16.4.5",
+    "express": "^4.18.2",
     "node-fetch": "^3.3.2",
-    "dotenv": "^16.4.5"
+    "openai": "^4.0.0",
+    "socket.io": "^4.7.2"
   }
 }
-


### PR DESCRIPTION
## Summary
- Add `chat` example implementing nickname-based 1-1 chat with Socket.IO and OpenAI fallback after 5 seconds.
- Include minimal frontend (`index.html`, `style.css`, `script.js`) and server powered by Express.
- Document setup and usage in new README and update package scripts and dependencies.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b468a7b158832990fd6058c268a6bc