### PR TITLE
Add category-based chat with AI fallback

### DIFF
--- a/chat/README.md
+++ b/chat/README.md
@@ -1,16 +1,24 @@
-# Hızlı Sohbet Uygulaması
+# Kategori Tabanlı Hızlı Sohbet
 
-Bu klasör, kullanıcıları hızlı şekilde eşleştiren ve kısa süre içinde eşleşme bulunamazsa yapay zekâ ile sohbet başlatan basit bir örnek uygulama içerir.
+Bu klasör, kullanıcıların kategori seçerek hızlıca eşleştiği ve kullanıcı bulunamazsa yapay zekâ ile sohbet edebildiği örnek bir uygulama içerir.
 
 ## Özellikler
 - Takma ad ile giriş
-- 1-1 hızlı sohbet için gerçek kullanıcı eşleştirmesi
-- 5 saniye içinde kullanıcı bulunamazsa otomatik yapay zekâ sohbeti
-- OpenAI API entegrasyonu
-- Socket.io ile gerçek zamanlı mesajlaşma
+- Kategorilere göre 1-1 eşleştirme
+- Eşleşme yoksa OpenAI ile sohbet
+- Gerçek zamanlı mesajlaşma (Socket.io)
+- "Yazıyor" göstergesi
+- Mesaj gönderildi / okundu bilgisi
+- Mesaj düzenleme ve silme
+- 30 sn sonra kaybolan mesajlar
+- Emoji reaksiyonları
+- Anket oluşturma ve oy kullanma
+- Taş-kağıt-makas mini oyunu
+- Tema ve arka plan seçimi
+- Basit küfür filtresi
 
 ## Kurulum
-1. Bağımlılıkları yükleyin (depo kökünde):
+1. Bağımlılıkları yükleyin (repo kökünde):
    ```bash
    npm install
    ```
@@ -25,4 +33,4 @@ Bu klasör, kullanıcıları hızlı şekilde eşleştiren ve kısa süre içind
 4. Tarayıcınızda [http://localhost:3000](http://localhost:3000) adresini açın.
 
 ## Not
-Bu örnek basit olması için hazırlanmıştır; gerçek üretim ortamları için ek güvenlik ve hata kontrolleri gereklidir.
+Bu örnek eğitim amaçlıdır; gerçek ortamlar için ek güvenlik ve kalıcılık önlemleri gerekir.

--- a/chat/index.html
+++ b/chat/index.html
@@ -2,20 +2,54 @@
 <html lang="tr">
 <head>
   <meta charset="UTF-8" />
-  <title>Hızlı Sohbet</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Kategori Sohbeti</title>
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
   <div id="login">
     <h2>Sohbete Katıl</h2>
-    <input id="nickname" placeholder="Takma ad" />
+    <input id="nickname" placeholder="Takma ad" maxlength="20" />
+    <select id="category">
+      <option value="genel">Genel Sohbet</option>
+      <option value="teknoloji">Teknoloji</option>
+      <option value="oyun">Oyun</option>
+      <option value="spor">Spor</option>
+    </select>
+    <div class="prefs">
+      <label>Tema:
+        <select id="themeSelect">
+          <option value="light">Açık</option>
+          <option value="dark">Koyu</option>
+        </select>
+      </label>
+      <label>Arka plan:
+        <input type="color" id="bgPicker" />
+      </label>
+    </div>
     <button id="joinBtn">Katıl</button>
   </div>
+
   <div id="chat" class="hidden">
+    <div id="infoBar">
+      <span id="peerStatus"></span>
+      <span id="typing" class="muted"></span>
+    </div>
     <div id="messages"></div>
-    <input id="msgInput" autocomplete="off" placeholder="Mesaj yaz..." />
-    <button id="sendBtn">Gönder</button>
+    <div id="compose">
+      <input id="msgInput" autocomplete="off" placeholder="Mesaj yaz..." />
+      <label class="ephemeral"><input type="checkbox" id="ephemeral" />30sn'de sil</label>
+      <button id="sendBtn">Gönder</button>
+    </div>
+    <div id="actions">
+      <button id="editBtn">Düzenle</button>
+      <button id="deleteBtn">Sil</button>
+      <button id="reactBtn">👍</button>
+      <button id="pollBtn">Anket</button>
+      <button id="rpsBtn">Taş-Kağıt-Makas</button>
+    </div>
   </div>
+
   <script src="/socket.io/socket.io.js"></script>
   <script src="script.js"></script>
 </body>

--- a/chat/script.js
+++ b/chat/script.js
@@ -3,47 +3,215 @@ const socket = io();
 const login = document.getElementById('login');
 const chat = document.getElementById('chat');
 const nicknameInput = document.getElementById('nickname');
+const categorySelect = document.getElementById('category');
 const joinBtn = document.getElementById('joinBtn');
 const messages = document.getElementById('messages');
 const msgInput = document.getElementById('msgInput');
 const sendBtn = document.getElementById('sendBtn');
+const typingEl = document.getElementById('typing');
+const ephemeralCheck = document.getElementById('ephemeral');
+
+const editBtn = document.getElementById('editBtn');
+const deleteBtn = document.getElementById('deleteBtn');
+const reactBtn = document.getElementById('reactBtn');
+const pollBtn = document.getElementById('pollBtn');
+const rpsBtn = document.getElementById('rpsBtn');
+
+const themeSelect = document.getElementById('themeSelect');
+const bgPicker = document.getElementById('bgPicker');
+
+// load preferences
+window.addEventListener('load', () => {
+  const t = localStorage.getItem('theme') || 'light';
+  themeSelect.value = t;
+  document.body.classList.toggle('dark', t === 'dark');
+  const bg = localStorage.getItem('bg');
+  if (bg) {
+    bgPicker.value = bg;
+    document.body.style.backgroundColor = bg;
+  }
+});
+
+themeSelect.addEventListener('change', e => {
+  const val = e.target.value;
+  document.body.classList.toggle('dark', val === 'dark');
+  localStorage.setItem('theme', val);
+});
+
+bgPicker.addEventListener('change', e => {
+  const val = e.target.value;
+  document.body.style.backgroundColor = val;
+  localStorage.setItem('bg', val);
+});
 
 joinBtn.addEventListener('click', () => {
   const nick = nicknameInput.value.trim();
   if (!nick) return;
-  socket.emit('join', nick);
+  socket.emit('join', { nickname: nick, category: categorySelect.value });
   login.classList.add('hidden');
   chat.classList.remove('hidden');
 });
 
+function uniqueId() {
+  return Date.now().toString(36) + Math.random().toString(36).slice(2);
+}
+
+function addMessage(msg) {
+  const div = document.createElement('div');
+  div.className = 'msg ' + (msg.nickname === 'Ben' ? 'self' : 'peer');
+  div.dataset.id = msg.id;
+  div.innerHTML = `<span class="text">${msg.text}</span> <span class="meta" id="meta-${msg.id}"></span>`;
+  messages.appendChild(div);
+  messages.scrollTop = messages.scrollHeight;
+}
+
 function send() {
   const text = msgInput.value.trim();
   if (text === '') return;
-  socket.emit('message', text);
-  addMessage('Ben', text);
+  const msg = { id: uniqueId(), text, ephemeral: ephemeralCheck.checked };
+  socket.emit('message', msg);
+  addMessage({ ...msg, nickname: 'Ben' });
   msgInput.value = '';
 }
 
 sendBtn.addEventListener('click', send);
-msgInput.addEventListener('keypress', e => {
-  if (e.key === 'Enter') send();
+msgInput.addEventListener('keypress', e => { if (e.key === 'Enter') send(); });
+
+msgInput.addEventListener('input', () => {
+  socket.emit('typing');
 });
 
-function addMessage(nick, text) {
+socket.on('typing', nick => {
+  typingEl.textContent = nick ? `${nick} yazıyor...` : '';
+  if (nick) {
+    setTimeout(() => { typingEl.textContent = ''; }, 1000);
+  }
+});
+
+socket.on('message', msg => {
+  addMessage(msg);
+  socket.emit('delivered', msg.id);
+  setTimeout(() => socket.emit('read', msg.id), 100);
+});
+
+socket.on('delivered', id => {
+  const meta = document.getElementById('meta-' + id);
+  if (meta) meta.textContent = '✓';
+});
+
+socket.on('read', id => {
+  const meta = document.getElementById('meta-' + id);
+  if (meta) meta.textContent = '✓✓';
+});
+
+editBtn.addEventListener('click', () => {
+  const last = Array.from(messages.querySelectorAll('.self')).pop();
+  if (!last) return;
+  const id = last.dataset.id;
+  const newText = prompt('Yeni mesaj', last.querySelector('.text').textContent);
+  if (!newText) return;
+  last.querySelector('.text').textContent = newText;
+  socket.emit('editMessage', { id, text: newText });
+});
+
+deleteBtn.addEventListener('click', () => {
+  const last = Array.from(messages.querySelectorAll('.self')).pop();
+  if (!last) return;
+  const id = last.dataset.id;
+  last.remove();
+  socket.emit('deleteMessage', { id });
+});
+
+reactBtn.addEventListener('click', () => {
+  const last = Array.from(messages.querySelectorAll('.peer')).pop();
+  if (!last) return;
+  const id = last.dataset.id;
+  let span = last.querySelector('.reactions');
+  if (!span) {
+    span = document.createElement('span');
+    span.className = 'reactions';
+    last.appendChild(span);
+  }
+  span.textContent += '👍';
+  socket.emit('reaction', { id, emoji: '👍' });
+});
+
+pollBtn.addEventListener('click', () => {
+  const question = prompt('Soru?');
+  if (!question) return;
+  const opts = prompt('Seçenekleri virgülle ayırın').split(',').map(s => s.trim()).filter(Boolean);
+  if (opts.length < 2) return;
+  const id = uniqueId();
+  socket.emit('poll', { id, question, options: opts });
+});
+
+function renderPoll(poll) {
   const div = document.createElement('div');
-  div.innerHTML = `<strong>${nick}:</strong> ${text}`;
+  div.className = 'poll';
+  div.dataset.id = poll.id;
+  const q = document.createElement('div');
+  q.textContent = poll.question;
+  div.appendChild(q);
+  poll.options.forEach((opt, i) => {
+    const btn = document.createElement('button');
+    btn.textContent = `${opt} (${poll.votes[i]})`;
+    btn.addEventListener('click', () => socket.emit('vote', { id: poll.id, option: i }));
+    div.appendChild(btn);
+  });
   messages.appendChild(div);
   messages.scrollTop = messages.scrollHeight;
 }
 
-socket.on('message', data => {
-  addMessage(data.nickname, data.text);
+socket.on('poll', poll => {
+  if (!poll.votes) poll.votes = new Array(poll.options.length).fill(0);
+  renderPoll(poll);
 });
 
-socket.on('system', msg => {
+socket.on('pollUpdate', poll => {
+  const div = messages.querySelector(`.poll[data-id="${poll.id}"]`);
+  if (!div) return;
+  const buttons = div.querySelectorAll('button');
+  buttons.forEach((btn, i) => {
+    btn.textContent = `${poll.options[i]} (${poll.votes[i]})`;
+  });
+});
+
+rpsBtn.addEventListener('click', () => {
+  const choice = prompt('Taş, Kağıt, Makas?').toLowerCase();
+  if (!choice) return;
+  socket.emit('rps', choice);
+});
+
+socket.on('rpsResult', msg => addSystem(msg));
+
+function addSystem(text) {
   const div = document.createElement('div');
   div.className = 'system';
-  div.textContent = msg;
+  div.textContent = text;
   messages.appendChild(div);
   messages.scrollTop = messages.scrollHeight;
+}
+
+socket.on('system', addSystem);
+
+socket.on('editMessage', data => {
+  const el = messages.querySelector(`[data-id="${data.id}"] .text`);
+  if (el) el.textContent = data.text;
+});
+
+socket.on('deleteMessage', data => {
+  const el = messages.querySelector(`[data-id="${data.id}"]`);
+  if (el) el.remove();
+});
+
+socket.on('reaction', data => {
+  const el = messages.querySelector(`[data-id="${data.id}"]`);
+  if (!el) return;
+  let span = el.querySelector('.reactions');
+  if (!span) {
+    span = document.createElement('span');
+    span.className = 'reactions';
+    el.appendChild(span);
+  }
+  span.textContent += data.emoji;
 });

--- a/chat/server.js
+++ b/chat/server.js
@@ -3,7 +3,6 @@ const express = require('express');
 const http = require('http');
 const { Server } = require('socket.io');
 const OpenAI = require('openai');
-const path = require('path');
 
 const app = express();
 const server = http.createServer(app);
@@ -12,26 +11,38 @@ const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
 app.use(express.static(__dirname));
 
-const waiting = [];
+const waiting = {}; // kategori -> bekleyen socketler
+const banned = ['küfür', 'hakaret'];
+
+function filter(text) {
+  let res = text;
+  banned.forEach(w => {
+    const re = new RegExp(w, 'gi');
+    res = res.replace(re, '***');
+  });
+  return res;
+}
 
 io.on('connection', socket => {
   let timeout;
 
-  socket.on('join', nickname => {
+  socket.on('join', ({ nickname, category }) => {
     socket.nickname = nickname || 'Anon';
-    if (waiting.length > 0) {
-      const peer = waiting.shift();
+    socket.category = category || 'genel';
+    const list = waiting[socket.category] || (waiting[socket.category] = []);
+    if (list.length > 0) {
+      const peer = list.shift();
       const room = `${socket.id}#${peer.id}`;
       socket.join(room);
       peer.join(room);
       socket.room = room;
       peer.room = room;
-      io.to(room).emit('system', `${socket.nickname} ve ${peer.nickname} bağlandı.`);
+      io.to(room).emit('system', `${socket.nickname} ve ${peer.nickname} bağlandı (${socket.category}).`);
     } else {
-      waiting.push(socket);
+      list.push(socket);
       timeout = setTimeout(() => {
-        const idx = waiting.indexOf(socket);
-        if (idx !== -1) waiting.splice(idx,1);
+        const idx = list.indexOf(socket);
+        if (idx !== -1) list.splice(idx, 1);
         socket.isWithAI = true;
         socket.room = socket.id;
         socket.join(socket.room);
@@ -40,31 +51,86 @@ io.on('connection', socket => {
     }
   });
 
-  socket.on('message', async text => {
+  socket.on('typing', () => {
+    if (socket.room && !socket.isWithAI) {
+      socket.to(socket.room).emit('typing', socket.nickname);
+    }
+  });
+
+  socket.on('message', async msg => {
+    msg.text = filter(msg.text);
     if (socket.isWithAI) {
       try {
         const completion = await openai.chat.completions.create({
           model: 'gpt-3.5-turbo',
           messages: [
-            { role: 'system', content: 'Sen arkadaşça sohbet eden yardımcı bir yapay zekâsın.' },
-            { role: 'user', content: text }
+            { role: 'system', content: `Sen ${socket.category} hakkında doğal ve samimi sohbet eden bir asistansın.` },
+            { role: 'user', content: msg.text }
           ]
         });
         const reply = completion.choices[0].message.content.trim();
-        socket.emit('message', { nickname: 'AI', text: reply });
+        socket.emit('message', { id: Date.now().toString(36), nickname: 'AI', text: reply });
       } catch (err) {
         console.error('AI error', err);
-        socket.emit('message', { nickname: 'AI', text: 'Bir hata oluştu.' });
+        socket.emit('system', 'AI hata verdi.');
       }
     } else if (socket.room) {
-      socket.to(socket.room).emit('message', { nickname: socket.nickname, text });
+      io.to(socket.room).emit('message', { ...msg, nickname: socket.nickname });
+      if (msg.ephemeral) {
+        setTimeout(() => io.to(socket.room).emit('deleteMessage', { id: msg.id }), 30000);
+      }
     }
+  });
+
+  socket.on('delivered', id => {
+    if (socket.room) socket.to(socket.room).emit('delivered', id);
+  });
+
+  socket.on('read', id => {
+    if (socket.room) socket.to(socket.room).emit('read', id);
+  });
+
+  socket.on('editMessage', data => {
+    if (socket.room) socket.to(socket.room).emit('editMessage', data);
+  });
+
+  socket.on('deleteMessage', data => {
+    if (socket.room) socket.to(socket.room).emit('deleteMessage', data);
+  });
+
+  socket.on('reaction', data => {
+    if (socket.room) socket.to(socket.room).emit('reaction', data);
+  });
+
+  const polls = new Map();
+  socket.on('poll', poll => {
+    polls.set(poll.id, { question: poll.question, options: poll.options, votes: new Array(poll.options.length).fill(0) });
+    io.to(socket.room).emit('poll', { ...poll, votes: new Array(poll.options.length).fill(0) });
+  });
+
+  socket.on('vote', ({ id, option }) => {
+    const poll = polls.get(id);
+    if (!poll) return;
+    poll.votes[option] = (poll.votes[option] || 0) + 1;
+    io.to(socket.room).emit('pollUpdate', { id, options: poll.options, votes: poll.votes });
+  });
+
+  socket.on('rps', choice => {
+    const opts = ['taş', 'kağıt', 'makas'];
+    const ai = opts[Math.floor(Math.random() * 3)];
+    let result = '';
+    if (choice === ai) result = 'Berabere';
+    else if ((choice === 'taş' && ai === 'makas') || (choice === 'kağıt' && ai === 'taş') || (choice === 'makas' && ai === 'kağıt'))
+      result = 'Kazandın';
+    else result = 'Kaybettin';
+    socket.emit('rpsResult', `AI ${ai} seçti, ${result}.`);
   });
 
   socket.on('disconnect', () => {
     if (timeout) clearTimeout(timeout);
-    const idx = waiting.indexOf(socket);
-    if (idx !== -1) waiting.splice(idx,1);
+    const list = waiting[socket.category] || [];
+    const idx = list.indexOf(socket);
+    if (idx !== -1) list.splice(idx, 1);
     if (socket.room && !socket.isWithAI) {
       socket.to(socket.room).emit('system', 'Sohbetten ayrıldı.');
     }

--- a/chat/style.css
+++ b/chat/style.css
@@ -1,6 +1,21 @@
+:root {
+  --bg: #f2f2f2;
+  --text: #222;
+  --bubble-self: #dcf8c6;
+  --bubble-peer: #fff;
+}
+
+body.dark {
+  --bg: #1e1e1e;
+  --text: #eee;
+  --bubble-self: #054740;
+  --bubble-peer: #333;
+}
+
 body {
   font-family: Arial, sans-serif;
-  background: #f2f2f2;
+  background: var(--bg);
+  color: var(--text);
   display: flex;
   justify-content: center;
   align-items: center;
@@ -10,28 +25,44 @@ body {
 
 .hidden { display: none; }
 
-#chat {
-  width: 320px;
-}
+#chat { width: 360px; }
 
 #messages {
   height: 300px;
   overflow-y: auto;
   border: 1px solid #ccc;
-  background: #fff;
+  background: var(--bubble-peer);
   padding: 5px;
   margin-bottom: 5px;
 }
 
-#msgInput {
-  width: 70%;
+.msg {
+  margin: 4px 0;
+  padding: 4px;
+  border-radius: 4px;
 }
 
-#sendBtn {
-  width: 28%;
-}
+.msg.self { background: var(--bubble-self); text-align: right; }
+.msg.peer { background: var(--bubble-peer); }
+.msg .meta { font-size: 0.75em; color: #666; }
+.reactions { margin-left: 4px; }
 
-.system {
-  color: #777;
-  font-style: italic;
+.poll {
+  border: 1px solid #ccc;
+  padding: 5px;
+  margin: 4px 0;
 }
+.poll button { margin-right: 4px; }
+
+#compose {
+  display: flex;
+  gap: 4px;
+}
+#msgInput { flex: 1; }
+#actions {
+  display: flex;
+  gap: 4px;
+  margin-top: 4px;
+  flex-wrap: wrap;
+}
+#typing { height: 1em; }


### PR DESCRIPTION
## Summary
- build category-based chat interface with theme/background preferences
- implement Socket.io server for matching by category with AI fallback and extras like reactions, polls and games
- document setup and features

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b46987bd88832983bfaec82abda1bc