### PR TITLE
Add profile and hashtag-based category management

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 Bu proje, kullanıcıların seçtikleri kategoriye göre başka bir kullanıcıyla 1-1 sohbet etmelerini sağlar. Aynı kategoride çevrimiçi kullanıcı yoksa, sohbet otomatik olarak yapay zekâ ile başlar.
 
 ## Özellikler
-- Rumuzla giriş
-- Sol tarafta kategori listesi
+- Profil bölümünden rumuz belirleme
+- Sol tarafta hashtag (#) ile başlayan kategori listesi
+- Ülke ve şehir seçerek veya elle kategori ekleme
 - WebSocket ile gerçek zamanlı eşleştirme
 - Kategoriye göre OpenAI desteği
 
@@ -24,9 +25,10 @@ Bu proje, kullanıcıların seçtikleri kategoriye göre başka bir kullanıcıy
 4. Tarayıcıdan `http://localhost:3000` adresine gidin.
 
 ## Kategoriler
-- Teknoloji
-- Oyun
-- Genel Sohbet
-- Spor
+- #Teknoloji
+- #Oyun
+- #Genel Sohbet
+- #Spor
+- Özel kategoriler (#Türkiye-İstanbul gibi)
 
 Bu proje eğitim amaçlıdır.

--- a/index.html
+++ b/index.html
@@ -9,13 +9,35 @@
 <body>
 <div class="app">
   <aside class="sidebar">
+    <div class="profile">
+      <h2>Profil</h2>
+      <input id="nickname" placeholder="Rumuz girin" />
+      <button id="saveProfile">Kaydet</button>
+    </div>
     <h2>Kategoriler</h2>
     <ul id="categories">
-      <li data-cat="Teknoloji">Teknoloji</li>
-      <li data-cat="Oyun">Oyun</li>
-      <li data-cat="Genel Sohbet">Genel Sohbet</li>
-      <li data-cat="Spor">Spor</li>
+      <li data-cat="#Teknoloji">#Teknoloji</li>
+      <li data-cat="#Oyun">#Oyun</li>
+      <li data-cat="#Genel Sohbet">#Genel Sohbet</li>
+      <li data-cat="#Spor">#Spor</li>
     </ul>
+    <div class="add-category">
+      <h3>Yeni Kategori</h3>
+      <select id="countrySelect">
+        <option value="">Ülke Seç</option>
+        <option value="Türkiye">Türkiye</option>
+        <option value="USA">USA</option>
+        <option value="Almanya">Almanya</option>
+        <option value="İngiltere">İngiltere</option>
+        <option value="Fransa">Fransa</option>
+        <option value="Hollanda">Hollanda</option>
+      </select>
+      <select id="citySelect">
+        <option value="">Şehir Seç</option>
+      </select>
+      <input id="customCategory" placeholder="#Kategori ekle" />
+      <button id="addCategory">Ekle</button>
+    </div>
   </aside>
   <main class="chat">
     <div id="messages" class="messages"></div>

--- a/script.js
+++ b/script.js
@@ -1,8 +1,17 @@
 const ws = new WebSocket(`ws://${location.host}`);
-let nickname = "";
-while (!nickname) {
-  nickname = prompt("Bir rumuz girin:");
-}
+
+let nickname = localStorage.getItem("nickname") || "";
+const nicknameInput = document.getElementById("nickname");
+const saveProfile = document.getElementById("saveProfile");
+if (nickname) nicknameInput.value = nickname;
+saveProfile.addEventListener("click", () => {
+  const value = nicknameInput.value.trim();
+  if (!value) return;
+  nickname = value;
+  localStorage.setItem("nickname", nickname);
+  alert("Profil kaydedildi");
+});
+
 let currentCategory = null;
 const messagesEl = document.getElementById("messages");
 
@@ -26,8 +35,12 @@ function clearMessages() {
   messagesEl.innerHTML = "";
 }
 
-document.querySelectorAll("#categories li").forEach((li) => {
+function attachCategory(li) {
   li.addEventListener("click", () => {
+    if (!nickname) {
+      alert("Lütfen önce profilinizi kaydedin.");
+      return;
+    }
     currentCategory = li.dataset.cat;
     clearMessages();
     ws.send(
@@ -38,6 +51,52 @@ document.querySelectorAll("#categories li").forEach((li) => {
       })
     );
   });
+}
+
+document.querySelectorAll("#categories li").forEach(attachCategory);
+
+const categoriesEl = document.getElementById("categories");
+const customCategoryInput = document.getElementById("customCategory");
+const addCategoryBtn = document.getElementById("addCategory");
+const countrySelect = document.getElementById("countrySelect");
+const citySelect = document.getElementById("citySelect");
+
+const cities = {
+  Türkiye: ["İstanbul", "Ankara", "İzmir"],
+  USA: ["New York", "Los Angeles", "Chicago"],
+  Almanya: ["Berlin", "Münih", "Hamburg"],
+  İngiltere: ["Londra", "Manchester", "Birmingham"],
+  Fransa: ["Paris", "Lyon", "Marsilya"],
+  Hollanda: ["Amsterdam", "Rotterdam", "Lahey"],
+};
+
+countrySelect.addEventListener("change", () => {
+  const country = countrySelect.value;
+  citySelect.innerHTML = '<option value="">Şehir Seç</option>';
+  if (country && cities[country]) {
+    cities[country].forEach((city) => {
+      const opt = document.createElement("option");
+      opt.value = city;
+      opt.textContent = city;
+      citySelect.appendChild(opt);
+    });
+  }
+});
+
+addCategoryBtn.addEventListener("click", () => {
+  let cat = customCategoryInput.value.trim();
+  if (!cat && countrySelect.value && citySelect.value) {
+    cat = `#${countrySelect.value}-${citySelect.value}`;
+  } else if (cat && !cat.startsWith("#")) {
+    cat = `#${cat}`;
+  }
+  if (!cat) return;
+  const li = document.createElement("li");
+  li.dataset.cat = cat;
+  li.textContent = cat;
+  attachCategory(li);
+  categoriesEl.appendChild(li);
+  customCategoryInput.value = "";
 });
 
 ws.onmessage = (event) => {
@@ -65,3 +124,4 @@ form.addEventListener("submit", (e) => {
   );
   input.value = "";
 });
+

--- a/style.css
+++ b/style.css
@@ -7,10 +7,10 @@ body {
   height: 100vh;
 }
 .sidebar {
-  width: 200px;
-  background: #f4f4f4;
-  padding: 10px;
-  box-sizing: border-box;
+    width: 200px;
+    background: #f4f4f4;
+    padding: 10px;
+    box-sizing: border-box;
 }
 .sidebar ul {
   list-style: none;
@@ -23,7 +23,26 @@ body {
   border-bottom: 1px solid #ddd;
 }
 .sidebar li:hover {
-  background: #ddd;
+    background: #ddd;
+}
+.profile,
+.add-category {
+    margin-bottom: 15px;
+}
+
+.profile input,
+.add-category input,
+.add-category select {
+    width: 100%;
+    padding: 5px;
+    margin-bottom: 5px;
+    box-sizing: border-box;
+}
+
+.profile button,
+.add-category button {
+    width: 100%;
+    padding: 5px;
 }
 .chat {
   flex: 1;


### PR DESCRIPTION
## Summary
- Add profile section for saving nicknames
- Enable hashtag categories with manual input and country/city selection
- Style new profile and category controls and update documentation

## Testing
- `npm test` *(fails: Invalid package.json: JSONParseError)*

------
https://chatgpt.com/codex/tasks/task_e_68b46ddc1d508329b1f5694fd3efa2ab